### PR TITLE
Use generics to simplify code and make to_sort_exprs smart

### DIFF
--- a/datafusion/core/src/physical_optimizer/sort_pushdown.rs
+++ b/datafusion/core/src/physical_optimizer/sort_pushdown.rs
@@ -127,9 +127,8 @@ pub(crate) fn pushdown_sorts(
             plan.equivalence_properties()
         }) {
             // If the current plan is a SortExec, modify it to satisfy parent requirements:
-            let parent_required_expr = PhysicalSortRequirement::to_sort_exprs(
-                parent_required.ok_or_else(err)?.iter().cloned(),
-            );
+            let parent_required_expr =
+                PhysicalSortRequirement::to_sort_exprs(parent_required.ok_or_else(err)?);
             new_plan = sort_exec.input.clone();
             add_sort_above(&mut new_plan, parent_required_expr)?;
         };
@@ -171,9 +170,8 @@ pub(crate) fn pushdown_sorts(
             }))
         } else {
             // Can not push down requirements, add new SortExec:
-            let parent_required_expr = PhysicalSortRequirement::to_sort_exprs(
-                parent_required.ok_or_else(err)?.iter().cloned(),
-            );
+            let parent_required_expr =
+                PhysicalSortRequirement::to_sort_exprs(parent_required.ok_or_else(err)?);
             let mut new_plan = plan.clone();
             add_sort_above(&mut new_plan, parent_required_expr)?;
             Ok(Transformed::Yes(SortPushDown::init(new_plan)))
@@ -209,9 +207,8 @@ fn pushdown_requirement_to_children(
     } else if let Some(smj) = plan.as_any().downcast_ref::<SortMergeJoinExec>() {
         // If the current plan is SortMergeJoinExec
         let left_columns_len = smj.left.schema().fields().len();
-        let parent_required_expr = PhysicalSortRequirement::to_sort_exprs(
-            parent_required.ok_or_else(err)?.iter().cloned(),
-        );
+        let parent_required_expr =
+            PhysicalSortRequirement::to_sort_exprs(parent_required.ok_or_else(err)?);
         let expr_source_side =
             expr_source_sides(&parent_required_expr, smj.join_type, left_columns_len);
         match expr_source_side {

--- a/datafusion/physical-expr/src/sort_expr.rs
+++ b/datafusion/physical-expr/src/sort_expr.rs
@@ -22,6 +22,7 @@ use arrow::compute::kernels::sort::{SortColumn, SortOptions};
 use arrow::record_batch::RecordBatch;
 use datafusion_common::{DataFusionError, Result};
 use datafusion_expr::ColumnarValue;
+use std::borrow::Borrow;
 use std::sync::Arc;
 
 /// Represents Sort operation for a column in a RecordBatch
@@ -192,12 +193,12 @@ impl PhysicalSortRequirement {
     ///
     /// This method is designed for
     /// use implementing [`ExecutionPlan::required_input_ordering`].
-    pub fn from_sort_exprs<'a>(
-        ordering: impl IntoIterator<Item = &'a PhysicalSortExpr>,
+    pub fn from_sort_exprs<T: Borrow<PhysicalSortExpr>>(
+        ordering: impl IntoIterator<Item = T>,
     ) -> Vec<PhysicalSortRequirement> {
         ordering
             .into_iter()
-            .map(PhysicalSortRequirement::from)
+            .map(|e| PhysicalSortRequirement::from(e.borrow()))
             .collect()
     }
 
@@ -207,12 +208,12 @@ impl PhysicalSortRequirement {
     /// This function converts `PhysicalSortRequirement` to `PhysicalSortExpr`
     /// for each entry in the input. If required ordering is None for an entry
     /// default ordering `ASC, NULLS LAST` if given (see [`into_sort_expr`])
-    pub fn to_sort_exprs(
-        requirements: impl IntoIterator<Item = PhysicalSortRequirement>,
+    pub fn to_sort_exprs<T: Borrow<PhysicalSortRequirement>>(
+        requirements: impl IntoIterator<Item = T>,
     ) -> Vec<PhysicalSortExpr> {
         requirements
             .into_iter()
-            .map(PhysicalSortExpr::from)
+            .map(|e| PhysicalSortExpr::from(e.borrow()))
             .collect()
     }
 

--- a/datafusion/physical-expr/src/sort_expr.rs
+++ b/datafusion/physical-expr/src/sort_expr.rs
@@ -22,7 +22,6 @@ use arrow::compute::kernels::sort::{SortColumn, SortOptions};
 use arrow::record_batch::RecordBatch;
 use datafusion_common::{DataFusionError, Result};
 use datafusion_expr::ColumnarValue;
-use std::borrow::Borrow;
 use std::sync::Arc;
 
 /// Represents Sort operation for a column in a RecordBatch
@@ -193,12 +192,15 @@ impl PhysicalSortRequirement {
     ///
     /// This method is designed for
     /// use implementing [`ExecutionPlan::required_input_ordering`].
-    pub fn from_sort_exprs<T: Borrow<PhysicalSortExpr>>(
+    pub fn from_sort_exprs<T>(
         ordering: impl IntoIterator<Item = T>,
-    ) -> Vec<PhysicalSortRequirement> {
+    ) -> Vec<PhysicalSortRequirement>
+    where
+        PhysicalSortRequirement: From<T>,
+    {
         ordering
             .into_iter()
-            .map(|e| PhysicalSortRequirement::from(e.borrow()))
+            .map(|e| PhysicalSortRequirement::from(e))
             .collect()
     }
 
@@ -208,12 +210,15 @@ impl PhysicalSortRequirement {
     /// This function converts `PhysicalSortRequirement` to `PhysicalSortExpr`
     /// for each entry in the input. If required ordering is None for an entry
     /// default ordering `ASC, NULLS LAST` if given (see [`into_sort_expr`])
-    pub fn to_sort_exprs<T: Borrow<PhysicalSortRequirement>>(
+    pub fn to_sort_exprs<T>(
         requirements: impl IntoIterator<Item = T>,
-    ) -> Vec<PhysicalSortExpr> {
+    ) -> Vec<PhysicalSortExpr>
+    where
+        PhysicalSortExpr: From<T>,
+    {
         requirements
             .into_iter()
-            .map(|e| PhysicalSortExpr::from(e.borrow()))
+            .map(|e| PhysicalSortExpr::from(e))
             .collect()
     }
 


### PR DESCRIPTION
PR to easily merge proposed use of `borrow`